### PR TITLE
added dial on canary sink object for external URI validation

### DIFF
--- a/pkg/ccl/changefeedccl/sink_external_connection.go
+++ b/pkg/ccl/changefeedccl/sink_external_connection.go
@@ -82,6 +82,9 @@ func validateExternalConnectionSinkURI(
 	if err != nil {
 		return errors.Wrap(err, "invalid changefeed sink URI")
 	}
+	if err := s.Dial(); err != nil {
+		return errors.Wrap(err, "failed to dial canary sink")
+	}
 	if err := s.Close(); err != nil {
 		return errors.Wrap(err, "failed to close canary sink")
 	}


### PR DESCRIPTION
Previously when we were creating an external connection, we create a canary sink to validate the configuration, like we do with regular feeds. however, we don't call Dial() on that sink, so the validation is less thorough.

Improved Validation with Dial():

Calling Dial() during canary sink validation offers a more comprehensive verification of the external connection.

Fixes #126992